### PR TITLE
Fix for item sorting NullReference Exception.

### DIFF
--- a/BetterChests/Framework/Features/OrganizeChest.cs
+++ b/BetterChests/Framework/Features/OrganizeChest.cs
@@ -67,10 +67,24 @@ internal sealed class OrganizeChest : Feature
 
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Harmony")]
     [SuppressMessage("StyleCop", "SA1313", Justification = "Harmony")]
-    private static bool ItemGrabMenu_organizeItemsInList_prefix(ItemGrabMenu __instance, IList<Item> items)
+    private static bool ItemGrabMenu_organizeItemsInList_prefix(ItemGrabMenu? __instance, IList<Item> items)
     {
-        if (!ReferenceEquals(__instance.ItemsToGrabMenu.actualInventory, items)
-         || BetterItemGrabMenu.Context is not { OrganizeChest: FeatureOption.Enabled })
+        if (BetterItemGrabMenu.Context?.OrganizeChest != FeatureOption.Enabled)
+        {
+            return true;
+        }
+
+        __instance ??= Game1.activeClickableMenu as ItemGrabMenu;
+
+        if (__instance?.ItemsToGrabMenu.actualInventory != items)
+        {
+            return true;
+        }
+
+        var groupBy = BetterItemGrabMenu.Context.OrganizeChestGroupBy;
+        var sortBy = BetterItemGrabMenu.Context.OrganizeChestSortBy;
+
+        if (groupBy == GroupBy.Default && sortBy == SortBy.Default)
         {
             return true;
         }


### PR DESCRIPTION
The `__instance` variable in the patch prefix can be null, which raised a NullReference Exception when sorting inventories.
This commit adds a check for that variable and sets it to the currently open ItemGrabMenu instance if needed.

Additionally, a check for the sort and group by values being default was added to this function, as there was a recursion that was caused by the `BetterItemGrabMenu.Context.OrganizeItems()` function, as it was calling the built-in organization function,  but the patch prefix called the above mentioned function again, causing recursion.
Now if the Sort and Group values are set to default for the inventory being sorted, the patch prefix calls the proper function as intended.