### PR TITLE
Custom Bush bugfix: Always mark bushes in a pot as such

### DIFF
--- a/CustomBush/Framework/Services/ModPatches.cs
+++ b/CustomBush/Framework/Services/ModPatches.cs
@@ -520,9 +520,10 @@ internal sealed class ModPatches
                 },
             };
 
+            __instance.bush.Value.inPot.Value = true;
+
             if (!__instance.Location.IsOutdoors)
             {
-                __instance.bush.Value.inPot.Value = true;
                 __instance.bush.Value.loadSprite();
                 Game1.playSound("coin");
             }


### PR DESCRIPTION
In vanilla `IndoorPot.performObjectDropInAction()`, when a tea bush is planted in a garden pot (AKA `IndoorPot`), the bush is always marked as being in a pot by setting the bush's `inPot.Value` property to `true`.

In SDV v1.5.6, this section was
```csharp
this.bush.Value = new Bush(base.tileLocation, 3, who.currentLocation);
if (!who.currentLocation.IsOutdoors)
{
	this.bush.Value.greenhouseBush.Value = true;
	this.bush.Value.loadSprite();
	Game1.playSound("coin");
}
```

As of SDV v1.6.0.24077-alpha, though, it had changed to
```csharp
NetRef<Bush> netRef = this.bush;
Bush obj = new Bush(base.tileLocation.Value, 3, this.Location);
obj.inPot.Value = true;
netRef.Value = obj;
if (!this.Location.IsOutdoors)
{
	this.bush.Value.loadSprite();
	Game1.playSound("coin");
}
```

The `this.bush.Value.greenhouseBush.Value = true;` line probably just got mis-ported to be `inPot` instead during the many builds of the alpha and changes it had over its developement.

This change just moves the line updating the Bush's `inPot` property to not be inside the `if` check so that it matches SDV v1.6 vanilla behavior.